### PR TITLE
Also update "latest" tag on Docker Hub

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,8 +1,17 @@
-- name: push
+- name: push_branch
   service: ubuntu
   type: push
   image_name: silintl/ubuntu
   image_tag: "{{.Branch}}"
   exclude: (master|main|snyk*)
+  registry: https://index.docker.io/v1/
+  encrypted_dockercfg_path: dockercfg.encrypted
+
+- name: push_latest
+  service: ubuntu
+  type: push
+  image_name: silintl/ubuntu
+  image_tag: "latest"
+  tag: (master|main)
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted


### PR DESCRIPTION
### Fixed
- Also update "latest" tag on Docker Hub

---

Our `latest` tag was last updated 3 years ago. This will at least fix that so all pushes on `main` will update the `latest` tag/image.

This is almost identical to [the corresponding file in the docker-php8 repo](https://github.com/silinternational/docker-php8/blob/develop/codeship-steps.yml).